### PR TITLE
From runtime

### DIFF
--- a/.changeset/six-dogs-listen.md
+++ b/.changeset/six-dogs-listen.md
@@ -1,0 +1,5 @@
+---
+"effect-react": patch
+---
+
+Add makeFromRuntime and makeFromRuntimeContext constructors to RuntimeProvider

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "@effect/language-service": "^0.0.21",
     "@effect/stream": "^0.36.0",
     "@repo-tooling/eslint-plugin-dprint": "^0.0.4",
+    "@testing-library/dom": "9.3.1",
     "@testing-library/jest-dom": "^6.1.3",
     "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^14.4.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,9 @@ devDependencies:
   '@repo-tooling/eslint-plugin-dprint':
     specifier: ^0.0.4
     version: 0.0.4(typescript@5.2.2)
+  '@testing-library/dom':
+    specifier: 9.3.1
+    version: 9.3.1
   '@testing-library/jest-dom':
     specifier: ^6.1.3
     version: 6.1.3(vitest@0.34.3)

--- a/src/RuntimeProvider.ts
+++ b/src/RuntimeProvider.ts
@@ -4,11 +4,11 @@ import * as Effect from "@effect/io/Effect"
 import * as Layer from "@effect/io/Layer"
 import type * as Runtime from "@effect/io/Runtime"
 import * as Scope from "@effect/io/Scope"
-import { createContext } from "react"
 import type { UseResult } from "effect-react/hooks/useResult"
 import { makeUseResult } from "effect-react/hooks/useResult"
 import type { UseResultCallback } from "effect-react/hooks/useResultCallback"
 import { makeUseResultCallback } from "effect-react/hooks/useResultCallback"
+import { createContext } from "react"
 
 export { RuntimeContext } from "effect-react/internal/runtimeContext"
 
@@ -31,6 +31,28 @@ export const makeFromLayer = <R, E>(
 
   const RuntimeContext = createContext(runtime)
 
+  return {
+    RuntimeContext,
+    useResultCallback: makeUseResultCallback(RuntimeContext),
+    useResult: makeUseResult(RuntimeContext)
+  }
+}
+
+export const makeFromRuntime = <R>(
+  runtime: Runtime.Runtime<R>
+): ReactEffectBag<R> => {
+  const RuntimeContext = createContext(runtime)
+
+  return {
+    RuntimeContext,
+    useResultCallback: makeUseResultCallback(RuntimeContext),
+    useResult: makeUseResult(RuntimeContext)
+  }
+}
+
+export const makeFromRuntimeContext = <R>(
+  RuntimeContext: React.Context<Runtime.Runtime<R>>
+): ReactEffectBag<R> => {
   return {
     RuntimeContext,
     useResultCallback: makeUseResultCallback(RuntimeContext),


### PR DESCRIPTION
I already have a global singleton runtime so I want to provide that instead of constructing a new one from a layer.

Added `@testing-library/dom` because results in tests get typed as `any` without it